### PR TITLE
Allow pickling/unpickling of MakerException

### DIFF
--- a/makerpy/maker.py
+++ b/makerpy/maker.py
@@ -20,6 +20,9 @@ class MakerException(Exception):
     def __str__(self):
         return self.message
 
+    def __reduce__(self):
+        return (self.__class__, (self.message, self.cause))
+
 ###############################################################################
 def resolve_class(kls):
     if kls == "dict":


### PR DESCRIPTION
Without this, problems with trying to create objects with MakerPy (if, say, your database or config file has typos in it and the class to "make" cannot be found) will be masked by pickle-related errors under eg `multiprocessing`.